### PR TITLE
Update API endpoints for MaxMind products and services

### DIFF
--- a/metadata/WEB-INF/classes/com/innovateteam/gpt/RecordMetrics.java
+++ b/metadata/WEB-INF/classes/com/innovateteam/gpt/RecordMetrics.java
@@ -120,7 +120,7 @@ public class RecordMetrics extends HttpServlet {
         if(rip!=null && rip.length() >= 7) {
             BufferedReader in = null;
             try {
-                URL geolocator = new URL("http://geoip3.maxmind.com/f?l=uHb8LATVUFub&i=" + rip);
+                URL geolocator = new URL("https://geoip.maxmind.com/f?l=uHb8LATVUFub&i=" + rip);
                 in = new BufferedReader(new InputStreamReader(geolocator.openStream()));
                 geoInfo = in.readLine();
             }


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)